### PR TITLE
Update bigip_pool_member.py to allow port = 0

### DIFF
--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -340,12 +340,12 @@ def main():
 
 
     # sanity check user supplied values
+    if 0 > port > 65535:
+        module.fail_json(msg="valid ports must be in range 0 - 65535")
 
-    if (host and not port) or (port and not host):
-        module.fail_json(msg="both host and port must be supplied")
 
-    if 1 > port > 65535:
-        module.fail_json(msg="valid ports must be in range 1 - 65535")
+    if (not host):
+        module.fail_json(msg="host must be supplied")
 
     try:
         api = bigip_api(server, user, password, validate_certs)


### PR DESCRIPTION
0 is a valid port (at least on our F5 appiance).  When port = 0, the logic of (host and not port) becomes true and the module fails.  To fix this, I changed the valid port check to allow 0 and moved it above the host and port sanity check.  At that point, the port is validated and only a sanity check for the host is necessary.
